### PR TITLE
Removed Reactive's Tips linke - 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,5 @@ You can read more about the `yield` keyword and blocks in Ruby from the resource
 * [All About Ruby](http://allaboutruby.wordpress.com/) - [Ruby Blocks](http://allaboutruby.wordpress.com/2006/01/20/ruby-blocks-101/)
 * [About.com](http://ruby.about.com/) - [Block Parameters and Yielding](http://ruby.about.com/od/beginningruby/a/Block-Parameters-And-Yielding.htm)
 * [Coda Hale's Blog](http://blog.codahale.com/2005/11/24/a-ruby-howto-writing-a-method-that-uses-code-blocks/) - [Writing a Method that Uses Code Blocks](http://blog.codahale.com/2005/11/24/a-ruby-howto-writing-a-method-that-uses-code-blocks/)
-* [Reactive's Tips](http://www.reactive.io/tips/) - [Understanding Ruby Blocks, Procs, and Lambdas](http://www.reactive.io/tips/2008/12/21/understanding-ruby-blocks-procs-and-lambdas/)
 
 <a href='https://learn.co/lessons/yield-and-blocks' data-visibility='hidden'>View this lesson on Learn.co</a>


### PR DESCRIPTION
The link to the reactive.io blog throws a 404 error. I couldn't find it anywhere on the site to update the link. Removed.
