### PR TITLE
add hello_t method to return names that start with T

### DIFF
--- a/lib/hello.rb
+++ b/lib/hello.rb
@@ -1,6 +1,22 @@
-def hello_t
-
+def hello_t(array)
+  if block_given?
+    i = 0
+    new_array = []
+    while i < array.length
+      if array[i].upcase.start_with?("T")
+        yield(array[i])
+        new_array << array[i]
+      end
+      i = i + 1
+    end
+    new_array
+  else
+    puts "Hey! No block was given!"
+  end
 end
 
-# call your method here!
-
+hello_t(["Tim", "Tom", "Jim"]) do |name|
+    if name.start_with?("T")
+        puts "Hi, #{name}"
+    end
+end


### PR DESCRIPTION
Codealong did not match tests. Not sure if the tests are wrong or the codealong is wrong, but it was helpful to build out the hello_t method to actually include the start_with?("T") method rather than having it basically be a duplicate of the .each method.